### PR TITLE
allow overriding views. closes #91

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -137,13 +137,16 @@ function Server (opts, cb) {
   * Set up the application's views
   */
 
-  this.views = {};
-  this.viewsDir = opts.viewsDir || __dirname + '/../views/';
-  this.createViews();
+  this.views = {}
+  this.viewsDir = path.join(__dirname, '/../views/');
+  this.viewData = { site: opts.site };
+  this.addViews();
 
-  this.viewData = {
-    site: this.site
-  };
+  if (opts.views) {
+    if (opts.views[opts.views.length - 1] !== '/')  opts.views += '/';
+    this.viewsOverrideDir = opts.views;
+    this.overrideViews();
+  }
   
   opts.cors || (opts.cors = {});
   
@@ -397,15 +400,20 @@ Server.prototype.route = function (path, cb) {
 * Create views on application startup
 */
 
-Server.prototype.createViews = function () {
+Server.prototype.addViews = function () {
   var self = this;
-
+  
   fs.readdir(this.viewsDir, function (err, files) {
     files.forEach(function (file) {
-      self.addView(file);
+      if (file === 'layout.html') {
+        var filepath = self.viewsDir + 'layout.html';
+        Handlebars.registerPartial('layout', fs.readFileSync(filepath, 'utf8'));
+      }
+      else self.addView(file);
     });
   });
-};
+}
+
 
 /*
 * Add a view to the list of views
@@ -413,15 +421,44 @@ Server.prototype.createViews = function () {
 
 Server.prototype.addView = function (file, viewsDir) {
   var dir = viewsDir || this.viewsDir;
-  this.views[file.split('.')[0]] = getView(dir + file);
-};
+  return this.views[file.split('.')[0]] = this.compileView(dir + file);
+}
+
+
+/*
+* compile a view
+*/
+
+Server.prototype.compileView = function (filepath) {
+  var template = Handlebars.compile(fs.readFileSync(filepath, 'utf8'));
+  return template;
+}
+
+
+/*
+* Override views
+*/
+
+Server.prototype.overrideViews = function () {
+  var self = this;
+
+  fs.readdir(this.viewsOverrideDir, function (err, files) {
+    files.forEach(function (file) {
+      if (file === 'layout.html') {
+        var filepath = self.viewsOverrideDir + 'layout.html';
+        Handlebars.registerPartial('layout', fs.readFileSync(filepath, 'utf8'));
+      }
+      else self.addView(file, self.viewsOverrideDir);
+    });
+  });
+}
 
 
 /*
 * Method for rendering html views
 */
 
-Server.prototype.render = function (view, ctx) {
-  var data = extend(this.viewData, (ctx || {}));
+Server.prototype.render = function (view, data) {
+  var data = extend(data || {}, this.viewData);
   return this.views[view](data);
 }


### PR DESCRIPTION
this lets us use custom views for routes. we create a view with the same name as a view that already exists in the system, then provide a `views` option that tells flatsheet where the custom views are:

```
var app = require('flatsheet')({
  views: __dirname + '/views',
});
```
