### PR TITLE
Make `npm test` work.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "main": "lib/index.js",
   "scripts": {
     "flatsheet": "./bin/flatsheet",
-    "test": "tape test.js",
+    "pretest": "node pretest",
+    "test": "tape 'tests/**/*.js'",
     "bundle-css": "rework-npm browser/style.css | myth | cleancss -o public/style.css",
     "watch-css": "gazer -p 'browser/style.css' 'rework-npm browser/style.css | myth > public/style.css'",
     "watch-sheet-edit": "watchify -d browser/sheet.js -o public/sheet.js -g brfs",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "flatsheet": "./bin/flatsheet",
     "pretest": "node pretest",
-    "test": "tape 'tests/**/*.js'",
+    "test": "tape \"tests/**/*.js\"",
     "bundle-css": "rework-npm browser/style.css | myth | cleancss -o public/style.css",
     "watch-css": "gazer -p 'browser/style.css' 'rework-npm browser/style.css | myth > public/style.css'",
     "watch-sheet-edit": "watchify -d browser/sheet.js -o public/sheet.js -g brfs",

--- a/pretest.js
+++ b/pretest.js
@@ -1,0 +1,5 @@
+var
+  fs = require('fs');
+
+// Ignores all errors, to achieve ignoring EEXIST.
+fs.mkdir('./tmp', function () {});


### PR DESCRIPTION
Includes making sure `tmp` dir exists.

Re: #130, #133.

I think this should work cross-platform, but someone else would have to verify that on Windows.

Maybe you'd prefer the `pretest.js` script somewhere else, like a `scripts` directory?